### PR TITLE
Opcode group 04 and 09 readability updates

### DIFF
--- a/gnt4/docs/guides/opcode_group/04.md
+++ b/gnt4/docs/guides/opcode_group/04.md
@@ -284,7 +284,7 @@ Enforce a range on a value. Value is `op1`. Range start is `op2` and range end i
 ```c
 val = op1
 min = op2
-max = sp
+max = *sp
 result = min // if under min, use min
 if (min <= val) {
     result = val // keep value as-is
@@ -294,6 +294,7 @@ if (min <= val) {
 }
 op1 = result
 cr = op1
+sp++
 ```
 
 ## 0415 i32_rand
@@ -306,9 +307,10 @@ Get a random integer. Range start `op2` is **inclusive** and range end `sp` is *
 
 ```c
 rand = hsdbase::HSD_Rand()
-rand = (sp - op2) * (rand & 0xffff)
+rand = (*sp - op2) * (rand & 0xffff)
 op1 = (op2 + (rand >> 0x10) + (rand < 0 && (rand & 0xffff) != 0))
 cr = op1
+sp++
 ```
 
 ## 0416 - i32_andcz

--- a/gnt4/docs/guides/opcode_group/04.md
+++ b/gnt4/docs/guides/opcode_group/04.md
@@ -5,7 +5,7 @@ Int operations (4 bytes).
 - [0400 - i32_debug](#0400---i32_debug)
 - [0401 - i32_float](#0401---i32_float)
 - [0402 - i32_mov](#0402---i32_mov)
-- [0403 - i32_and.](#0403---i32_and)
+- [0403 - i32_andc](#0403---i32_andc)
 - [0404 - i32_nimply](#0404---i32_nimply)
 - [0405 - i32_inc](#0405---i32_inc)
 - [0406 - i32_dec](#0406---i32_dec)
@@ -22,136 +22,332 @@ Int operations (4 bytes).
 - [0411 - i32_sub.](#0411---i32_sub)
 - [0412 - i32_chs](#0412---i32_chs)
 - [0413 - i32_cuhw](#0413---i32_cuhw)
-- [0414](#0414)
-- [0415](#0415)
-- [0416](#0416)
-- [0417](#0417)
-- [0418](#0418)
+- [0414 - i32_range](#0414---i32_range)
+- [0415 - i32_rand](#0415---i32_rand)
+- [0416 - i32_andcz](#0416---i32_andcz)
+- [0417 - i32_mod](#0417---i32_mod)
+- [0418 - i32_abs](#0418---i32_abs)
 
 ## 0400 - i32_debug
 
-Debug `sprintf` the given parameter using the print format `"0x%x(%d)"`.
+Debug `sprintf` the given parameter using the print format `"0x%x(%d) "`.
 
 ## 0401 - i32_float
 
 Convert integer to float.
 
-Get two integers from `SEQ_RegCMD2`. Convert the second into a float and store it in the first.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+
+```c
+op1 = (float) op2
+```
 
 ## 0402 - i32_mov
 
 Move integer.
 
-Get two integers from `SEQ_RegCMD2`. Move the second into the first (`first = second`). Store the first value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 0403 - i32_and.
+```c
+op1 = op2
+cr = op1
+```
 
-Integer logical and (without store).
+## 0403 - i32_andc
 
-Get two integers from `SEQ_RegCMD2`. Logical `and` the first value with the second value and store the result in `cr` (`cr = first & second`).
+Integer logical and (compare).
+
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the conditional register `cr`.
+
+```c
+cr = op1 & op2
+```
 
 ## 0404 - i32_nimply
 
 Integer non-implication.
 
-Get two integers from `SEQ_RegCMD2`. Logical `not` the second value and logical `and` the result with the `first`; store this new result into the first (`first = first & ~second`). Store the result into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 & ~op2
+cr = op1
+```
 
 ## 0405 - i32_inc
 
 Integer increment.
 
-Get one integer from `SEQ_RegCMD1`. Increment and store it (`value = value++`). Store the result into `cr`.
+- One operand from `SEQ_RegCMD1`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 + 1
+cr = op1
+```
 
 ## 0406 - i32_dec
 
 Integer decrement.
 
-Get one integer from `SEQ_RegCMD1`. Decrement and store it (`value = value--`). Store the result into `cr`.
+- One operand from `SEQ_RegCMD1`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 - 1
+cr = op1
+```
 
 ## 0407 - i32_add
 
-Integer add.
+Integer addition.
 
-Get two integers from `SEQ_RegCMD2`. Add them and store the result in the first (`first = first + second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 + op2
+cr = op1
+```
 
 ## 0408 - i32_sub
 
-Integer subtract.
+Integer subtraction.
 
-Get two integers from `SEQ_RegCMD2`. Subtract them and store the result in the first (`first = first - second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 - op2
+cr = op1
+```
 
 ## 0409 - i32_mul
 
 Integer multiply.
 
-Get two integers from `SEQ_RegCMD2`. Multiply them and store the result in the first (`first = first * second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 * op2
+cr = op1
+```
 
 ## 040A - i32_div
 
 Integer divide.
 
-Get two integers from `SEQ_RegCMD2`. Divide them and store the result in the first (`first = first / second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 / op2
+cr = op1
+```
 
 ## 040B - i32_shl
 
 Integer shift left.
 
-Get two integers from `SEQ_RegCMD2`. Shift the first value left by the second value and store the result in the first (`first = first << second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 << op2
+cr = op1
+```
 
 ## 040C - i32_shr
 
 Integer shift right.
 
-Get two integers from `SEQ_RegCMD2`. Shift the first value right by the second value and store the result in the first (`first = first >> second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 >> (op2 & 0x3f)
+cr = op1
+```
 
 ## 040D - i32_and
 
 Integer logical and.
 
-Get two integers from `SEQ_RegCMD2`. Logical `and` the first value with the second value and store the result in the first (`first = first & second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 & op2
+cr = op1
+```
 
 ## 040E - i32_or
 
 Integer logical or.
 
-Get two integers from `SEQ_RegCMD2`. Logical `or` the first value with the second value and store the result in the first (`first = first | second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 | op2
+cr = op1
+```
 
 ## 040F - i32_xor
 
 Integer logical xor.
 
-Get two integers from `SEQ_RegCMD2`. Logical `xor` the first value with the second value and store the result in the first (`first = first ^ second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = op1 ^ op2
+cr = op1
+```
 
 ## 0410 - i32_not
 
 Integer logical not.
 
-Get two integers from `SEQ_RegCMD2`. Logical `not` the second value and store the result in the first (`first = ~second`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 0411 - i32_sub.
+```c
+op1 = ~op2
+cr = op1
+```
 
-Integer subtraction (without store).
+## 0411 - i32_subc
 
-Get two integers from `SEQ_RegCMD2`. Subtract them and store the result in `cr` (`cr = first - second`).
+Integer subtraction (compare).
+
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the conditional register `cr`.
+
+```c
+cr = op1 - op2
+```
 
 ## 0412 - i32_chs
 
 Integer change sign.
 
-Get two integers from `SEQ_RegCMD2`. Change the sign of the second value and store the result in the first (`first = -(second)`). Store the new value into `cr`.
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = -(op2)
+cr = op1
+```
 
 ## 0413 - i32_cuhw
 
-Integer clear upper half-word.
+Integer clear upper half-word (16 bytes).
 
-Get two integers from `SEQ_RegCMD2`. Clear the upper half-word of the second and store it in the first (`first = (second << 0x10 | second >> 0x10) >> 0x10`)
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 0414
+```c
+op1 = (op2 << 0x10 | op2 >> 0x10) >> 0x10
+cr = op1
+```
 
-## 0415
+## 0414 i32_range
 
-## 0416
+Enforce a range on a value. Value is `op1`. Range start is `op2` and range end is `sp`.
 
-## 0417
+- Two operands from `SEQ_RegCMD2` and pops one value from the stack register `sp`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 0418
+```c
+val = op1
+min = op2
+max = sp
+result = min // if under min, use min
+if (min <= val) {
+    result = val // keep value as-is
+    if (max < val) {
+        result = max // if over max, use max
+    }
+}
+op1 = result
+cr = op1
+```
+
+## 0415 i32_rand
+
+Get a random integer. Range start `op2` is **inclusive** and range end `sp` is **exclusive**, that is, `[op2, sp)`.
+
+- Two operands from `SEQ_RegCMD2` and pops one value from the stack register `sp`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+rand = hsdbase::HSD_Rand()
+rand = (sp - op2) * (rand & 0xffff)
+op1 = (op2 + (rand >> 0x10) + (rand < 0 && (rand & 0xffff) != 0))
+cr = op1
+```
+
+## 0416 - i32_andcz
+
+Integer logical and (compare). If the result does not equal `op2`, set `cr` to zero instead.
+
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the conditional register `cr`.
+
+```c
+temp = op1 & op2
+if (temp == op2) {
+    cr = temp
+} else {
+    cr = 0
+}
+```
+
+## 0417 - i32_mod
+
+Integer modulo.
+
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
+
+```c
+op1 = (op1 - (op1 / op2) * op2) // op1 % op2
+cr = op1
+```
+
+## 0418 - i32_abs
+
+Integer absolute value.
+
+- One operand from `SEQ_RegCMD1`.
+- Stores result in the first operand.
+
+```c
+temp = op1 >> 0x1f // get sign
+op1 = (temp ^ op1) - temp
+```

--- a/gnt4/docs/guides/opcode_group/09.md
+++ b/gnt4/docs/guides/opcode_group/09.md
@@ -2,68 +2,378 @@
 
 Pointer operations (4 bytes).
 
-## 0900
+- [0900 - ptr_debug](#0900---ptr_debug)
+- [0901 - ptr_mov](#0901---ptr_mov)
+- [0902 - ptr_inc](#0902---ptr_inc)
+- [0903 - ptr_dec](#0903---ptr_dec)
+- [0904 - ptr_add](#0904---ptr_add)
+- [0905 - ptr_sub](#0905---ptr_sub)
+- [0906 - ptr_subc](#0906---ptr_subc)
+- [0907 - ptr_move](#0907---ptr_move)
+- [0908 - ptr_from_offset](#0908---ptr_from_offset)
+- [0909 - ptr_to_offset](#0909---ptr_to_offset)
+- [090A - ptr_push](#090A---ptr_push)
+- [090B - ptr_pop](#090B---ptr_pop)
+- [090C - ptr_table_lookup](#090C---ptr_table_lookup)
+- [0914 - ptr_b](#0914---ptr_b)
+- [0915 - ptr_beqz](#0915---ptr_beqz)
+- [0916 - ptr_bnez](#0916---ptr_bnez)
+- [0917 - ptr_bgtz](#0917---ptr_bgtz)
+- [0918 - ptr_bgez](#0918---ptr_bgez)
+- [0919 - ptr_bltz](#0919---ptr_bltz)
+- [091A - ptr_blez](#091A---ptr_blez)
+- [091B - ptr_bltz](#091B---ptr_bltz)
+- [091C - ptr_bgez](#091C---ptr_bgez)
+- [091D - ptr_bl](#091D---ptr_bl)
+- [091E - ptr_beqzal](#091E---ptr_beqzal)
+- [091F - ptr_bnezal](#091F---ptr_bnezal)
+- [0920 - ptr_bgtzal](#0920---ptr_bgtzal)
+- [0921 - ptr_bgezal](#0921---ptr_bgezal)
+- [0922 - ptr_bltzal](#0922---ptr_bltzal)
+- [0923 - ptr_blezal](#0923---ptr_blezal)
+- [0924 - ptr_bltzal](#0924---ptr_bltzal)
+- [0925 - ptr_bgezal](#0925---ptr_bgezal)
+- [0926](#0926)
 
-## 0901
+## 0900 - ptr_debug
 
-## 0902
+Debug `sprintf` the given parameter using the print format `"0x%08x "`.
 
-## 0903
+## 0901 - ptr_mov
 
-## 0904
+Move pointer.
 
-## 0905
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 0906
+```c
+op1 = op2
+cr = op1
+```
 
-## 0907
+## 0902 - ptr_inc
 
-## 0908
+WARNING: This opcode is broken in GNT4, as it increments `sp` instead of the operand.
 
-## 0909
+Pointer increment.
 
-## 090A
+- One operand from `SEQ_RegCMD1`.
+- Stores result in the conditional register `cr`.
 
-## 090B
+```c
+sp++ // coding mistake by Eighting, should be op++
+cr = op1
+```
 
-## 090C
+## 0903 - ptr_dec
 
-## 0914
+Pointer decrement. This will decrement by the size of a word (4 bytes).
 
-## 0915
+- One operand from `SEQ_RegCMD1`.
+- Stores result in the operand.
+- Stores result in the conditional register `cr`.
 
-## 0916
+```c
+op1--
+cr = op1
+```
 
-## 0917
+## 0904 - ptr_add
 
-## 0918
+Pointer addition.
 
-## 0919
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 091A
+```c
+op1 = op1 + op2
+cr = op1
+```
 
-## 091B
+## 0905 - ptr_sub
 
-## 091C
+Pointer subtraction.
 
-## 091D
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+- Stores result in the conditional register `cr`.
 
-## 091E
+```c
+op1 = op1 - op2
+cr = op1
+```
 
-## 091F
+## 0906 - ptr_subc
 
-## 0920
+Pointer subtraction (compare).
 
-## 0920
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the conditional register `cr`.
 
-## 0921
+```c
+cr = op1 - op2
+```
 
-## 0922
+## 0907 - ptr_move
 
-## 0923
+Move pointer (ephemeral). Ephemeral in this case means it does not store to `cr`.
 
-## 0924
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
 
-## 0925
+```c
+op1 = op2
+```
+
+## 0908 - ptr_from_offset
+
+Convert an SEQ offset to an SEQ pointer address.
+
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+
+```c
+op1 = SEQ_START_PTR + op2
+```
+
+## 0909 - ptr_to_offset
+
+Convert an SEQ pointer address to an SEQ offset.
+
+- Two operands from `SEQ_RegCMD2`.
+- Stores result in the first operand.
+
+```c
+op1 = op2 - SEQ_START_PTR
+```
+
+## 090A - ptr_push
+
+Push a pointer to the stack.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+sp--
+sp = op1
+```
+
+## 090B - ptr_pop
+
+Pop a pointer from the stack.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+op1 = sp
+sp++
+```
+
+## 090C - ptr_table_lookup
+
+Lookup a value from a table in the SEQ file. `op2` is the index to lookup in the table and `var1` is the offset of the table from the start of the SEQ file. The result is stored in `op1`.
+
+- Two operands from `SEQ_RegCMD2` and one operand following the opcode.
+- Stores result in the first operand.
+
+```c
+op1 = SEQ_START_PTR + var1 + op2 * 4;
+```
+
+## 0914 - ptr_b
+
+Pointer branch.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+pc = SEQ_START_PTR + op1
+```
+
+## 0915 - ptr_beqz
+
+Pointer branch if equal to zero.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr == 0) {
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0916 - ptr_bnez
+
+Pointer branch if not equal to zero.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr != 0) {
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0917 - ptr_bgtz
+
+Pointer branch if greater than zero.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr > 0) {
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0918 - ptr_bgez
+
+Pointer branch if greater than or equal to zero.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr >= 0) {
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0919 - ptr_bltz
+
+Pointer branch if less than zero.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr < 0) {
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 091A - ptr_blez
+
+Pointer branch is less than or equal to zero.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr <= 0) {
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 091B - ptr_bltz
+
+Duplicate of [0919 - ptr_bltz](#0919---ptr_bltz)
+
+## 091C - ptr_bgez
+
+Duplicate of [0918 - ptr_bgez](#0918---ptr_bgez)
+
+## 091D - ptr_bl
+
+Pointer branch and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+sp--
+sp = NEXT_OPCODE
+pc = SEQ_START_PTR + op1
+```
+
+## 091E - ptr_beqzal
+
+Pointer branch if equal to zero and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr == 0) {
+    sp--
+    sp = NEXT_OPCODE
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 091F - ptr_bnezal
+
+Pointer branch if not equal to zero and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr != 0) {
+    sp--
+    sp = NEXT_OPCODE
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0920 - ptr_bgtzal
+
+Branch if greater than zero and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr > 0) {
+    sp--
+    sp = NEXT_OPCODE
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0921 - ptr_bgezal
+
+Branch if greater than or equal to zero and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr >= 0) {
+    sp--
+    sp = NEXT_OPCODE
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0922 - ptr_bltzal
+
+Pointer branch if less than zero and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr < 0) {
+    sp--
+    sp = NEXT_OPCODE
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0923 - ptr_blezal
+
+Pointer branch if less than or equal to zero and link.
+
+- One operand from `SEQ_RegCMD1`.
+
+```c
+if (cr <= 0) {
+    sp--
+    sp = NEXT_OPCODE
+    pc = SEQ_START_PTR + op1
+}
+```
+
+## 0924 - ptr_bltzal
+
+Duplicate of [0922 - ptr_bltzal](#0922---ptr_bltzal)
+
+## 0925 - ptr_bgezal
+
+Duplicate of [0921 - ptr_bgezal](#0921---ptr_bgezal)
 
 ## 0926

--- a/gnt4/docs/guides/opcode_group/09.md
+++ b/gnt4/docs/guides/opcode_group/09.md
@@ -157,7 +157,7 @@ Push a pointer to the stack.
 
 ```c
 sp--
-sp = op1
+*sp = op1
 ```
 
 ## 090B - ptr_pop
@@ -167,7 +167,7 @@ Pop a pointer from the stack.
 - One operand from `SEQ_RegCMD1`.
 
 ```c
-op1 = sp
+op1 = *sp
 sp++
 ```
 
@@ -280,7 +280,7 @@ Pointer branch and link.
 
 ```c
 sp--
-sp = NEXT_OPCODE
+*sp = NEXT_OPCODE
 pc = SEQ_START_PTR + op1
 ```
 
@@ -293,7 +293,7 @@ Pointer branch if equal to zero and link.
 ```c
 if (cr == 0) {
     sp--
-    sp = NEXT_OPCODE
+    *sp = NEXT_OPCODE
     pc = SEQ_START_PTR + op1
 }
 ```
@@ -307,7 +307,7 @@ Pointer branch if not equal to zero and link.
 ```c
 if (cr != 0) {
     sp--
-    sp = NEXT_OPCODE
+    *sp = NEXT_OPCODE
     pc = SEQ_START_PTR + op1
 }
 ```
@@ -321,7 +321,7 @@ Branch if greater than zero and link.
 ```c
 if (cr > 0) {
     sp--
-    sp = NEXT_OPCODE
+    *sp = NEXT_OPCODE
     pc = SEQ_START_PTR + op1
 }
 ```
@@ -335,7 +335,7 @@ Branch if greater than or equal to zero and link.
 ```c
 if (cr >= 0) {
     sp--
-    sp = NEXT_OPCODE
+    *sp = NEXT_OPCODE
     pc = SEQ_START_PTR + op1
 }
 ```
@@ -349,7 +349,7 @@ Pointer branch if less than zero and link.
 ```c
 if (cr < 0) {
     sp--
-    sp = NEXT_OPCODE
+    *sp = NEXT_OPCODE
     pc = SEQ_START_PTR + op1
 }
 ```
@@ -363,7 +363,7 @@ Pointer branch if less than or equal to zero and link.
 ```c
 if (cr <= 0) {
     sp--
-    sp = NEXT_OPCODE
+    *sp = NEXT_OPCODE
     pc = SEQ_START_PTR + op1
 }
 ```

--- a/gnt4/docs/guides/seq_decomp.md
+++ b/gnt4/docs/guides/seq_decomp.md
@@ -591,6 +591,12 @@ So for example, `game00.seq` starts with `0x00000006`, so it will initialize a `
 
 The third parameter `pc` is a pointer to the current opcode being executed in the seq file. It will move from opcode to opcode and branch when told to. When set to 0 it will cease executing opcodes.
 
+## Operand Names
+
+- `op1` - The operand from `SEQ_RegCMD1` or the first operand from `SEQ_RegCMD2`.
+- `op2` - The second operand from `SEQ_RegCMD2`.
+- `varX` - An operand that follows after the opcode word, where X is the index (starting at 1).
+
 ## Known Values
 
 The structs for `reg_p` seem to all be next to each other in memory.


### PR DESCRIPTION
This PR makes a number of updates to the documentation of primitive opcodes, specifically groups 04 and 09. Descriptions are simplified, bullets are included for important pieces of information, and C-style snippets are included to show what the opcode exactly does.

The new pages can be previewed here:
https://github.com/NicholasMoser/Naruto-GNT-Modding/blob/doc_op_update/gnt4/docs/guides/opcode_group/04.md
https://github.com/NicholasMoser/Naruto-GNT-Modding/blob/doc_op_update/gnt4/docs/guides/opcode_group/09.md