### PR TITLE
Note which opcodes are called by costume_model_physics

### DIFF
--- a/gnt4/docs/guides/opcode_group/27.md
+++ b/gnt4/docs/guides/opcode_group/27.md
@@ -3,32 +3,57 @@
 27XXYYZZ
 
 ## 2700
+
 - Takes 0 extra arguments
 - Call SEQ_RegCMD1
 - Execute zz_80072388 with the result of SEQ_RegCMD1
 
 ## 2701
+
 - Takes 0 extra arguments
 - Call SEQ_RegCMD1
 - Execute zz_800722f0 with the result of SEQ_RegCMD1
 
 ## 2702
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 - Takes two extra arguments
 - Call SEQ_RegCMD1
 - Second extra argument is offset to binary data in seq
 - Execute zz_800766f4 with the result of SEQ_RegCMD1, arg2, arg1, 1
 
 ## 2703
+
 - Takes a variable amount of extra arguments
 - Call SEQ_RegCMD2
 - Execute zz_800730bc with the results from SEQ_RegCMD2
 
 ## 2704
+
 - Takes no extra arguments
 - Call SEQ_RegCMD1
 - If result from SEQ_RegCMD1 is not null -> Execute zz_80076664
 
+## 2705
+
+## 2706
+
+## 2707
+
+## 2708
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
+## 2709
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 ## 270A
+
 - Takes a variable amount of extra arguments depending on YY
 - If YY > 0x2 -> Call SEQ_RegCMD1
 ### 00
@@ -47,17 +72,25 @@
 - Execute zz_80076ad8 with result from SEQ_RegCMD1, arg1, arg2
 
 ## 270B
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 - Takes two extra arguments
 - Second extra argument is offset to binary data
 - Sets float values
 
 ## 270C
+
 - Takes one indirect argument
 - Call SEQ_RegCMD2
 - Multiply indirect argument with 0xa4 and add 0x3c as arg
 - Write second result from SEQ_RegCMD2 to offset arg from the address at offset 0x104 from the first result as a single precision float
 
+## 270D
+
 ## 270E
+
 - Takes one extra argument
 - Call SEQ_RegCMD1
 - Multiply argument with 0xa4, add to the value in offset 0x104 from the result of SEQ_RegCMD1 as D
@@ -65,6 +98,10 @@
 - D->0x34 = FLOAT_80279794
 
 ## 270F
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 - Takes three extra arguments
 - Second extra argument is offset to the start to binary data
 - Third extra argument is offset to the end of said binary data
@@ -73,24 +110,47 @@
 - D->0x9C = seq_start + argument2
 - D->0xa0 = seq_start + argument3
 
+## 2710
+
 ## 2711
+
 - Takes no extra arguments
 - Call SEQ_RegCMD2
 - Execute zz_80072fc8 with the results from SEQ_RegCMD2
 
+## 2712
+
+## 2713
+
 ## 2714
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 - Takes two extra arguments
 - Second extra argument offset to binary data
 - Calls SEQ_RegCMD1
 - Execute zz_80076b90
 
+## 2715
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 ## 2716
+
 - Takes no extra arguments
 - Calls SEQ_RegCMD1
 - If the next op_code >> 8 & 0xff equals 0, then execute 800722a4 with result as argument
 - Else execute zz_80072258 with result as argument
 
+## 2717
+
+Called by `costume_model_physics` in the character SEQ code to put physics on a specific part of a model.
+Examples include Temari's sash and Ino's hair.
+
 ## 2718
+
 - Takes one extra argument
 - Calls SEQ_RegCMD1
 - Multiply argument1 with 0xa4, add to the value in offset 0x104 from the result of SEQ_RegCMD1 as D
@@ -111,14 +171,44 @@
 - D->0x100 = 0 (short)
 - seq_p_sp->0x5C += 4
 
+## 2719
+
 ## 271A
+
 - Takes one extra argument
 - Calls SEQ_RegCMD1
 - Multiply argument1 with 0xa4, add to the value in offset 0x104 from the result of SEQ_RegCMD1 as D
 - D->0x7c = 0
 - D->0x04 &= 0xeef7fbff
 
+## 271B
+
+## 271C
+
+## 2728
+
+## 2729
+
+## 272A
+
+## 272B
+
+## 272C
+
+## 272D
+
+## 272E
+
+## 272F
+
+## 2730
+
+## 2731
+
+## 2732
+
 ## 2780
+
 - Takes one extra argument
 - Calls SEQ_RegCMD1
 - Execute zz_80076c4c with arguments result SEQ_RegCMD1, arg1>>0x10, arg1 & 0xffff


### PR DESCRIPTION
All character 0000.seq files have a method called `costume_model_physics` responsible for attaching physics to parts of the character model. This PR updates opcodes related to this method.